### PR TITLE
Add ! after function

### DIFF
--- a/colors/solo.vim
+++ b/colors/solo.vim
@@ -47,7 +47,7 @@ else
   let s:bglighter = s:base2
 endif
 
-function s:style(fmt, fg, bg)
+function! s:style(fmt, fg, bg)
   return " gui=NONE".a:fmt." cterm=NONE".a:fmt." term=NONE".a:fmt
       \ ." guifg=".a:fg." ctermfg=".a:fg
       \ ." guibg=".a:bg." ctermbg=".a:bg


### PR DESCRIPTION
Why:

* I get an error in nvim 0.2.0 (Ubuntu 16.04.3)
  "E122: Function <SNR>2_style already exists, add ! to replace it"

This change adresses the need by:

* Adding a ! after function to force overwriting